### PR TITLE
Thread safety

### DIFF
--- a/ReSwift/CoreTypes/Store.swift
+++ b/ReSwift/CoreTypes/Store.swift
@@ -112,9 +112,8 @@ open class Store<State: StateType>: StoreType {
     open func _defaultDispatch(action: Action) {
         objc_sync_enter(self)
         let newState = reducer(action, state)
-        objc_sync_exit(self)
-
         state = newState
+        objc_sync_exit(self)
     }
 
     open func dispatch(_ action: Action) {

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -23,9 +23,7 @@ extension StoreSubscriber {
     // swiftlint:disable:next identifier_name
     public func _newState(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
-            DispatchQueue.main.sync {
-                newState(state: typedState)
-            }
+            newState(state: typedState)
         }
     }
 }

--- a/ReSwift/CoreTypes/StoreSubscriber.swift
+++ b/ReSwift/CoreTypes/StoreSubscriber.swift
@@ -23,7 +23,9 @@ extension StoreSubscriber {
     // swiftlint:disable:next identifier_name
     public func _newState(state: Any) {
         if let typedState = state as? StoreSubscriberStateType {
-            newState(state: typedState)
+            DispatchQueue.main.sync {
+                newState(state: typedState)
+            }
         }
     }
 }

--- a/ReSwiftTests/TestFakes.swift
+++ b/ReSwiftTests/TestFakes.swift
@@ -59,6 +59,18 @@ struct SetValueAction: Action {
     }
 }
 
+class DelayedAction: Action {
+    var blocked: Bool = true
+    var called: Bool = false
+    let value: Int?
+
+    func unblock() { blocked = false }
+
+    init(_ value: Int) {
+        self.value = value
+    }
+}
+
 struct SetValueStringAction: Action {
 
     var value: String
@@ -85,6 +97,11 @@ struct TestReducer {
 
         switch action {
         case let action as SetValueAction:
+            state.testValue = action.value
+            return state
+        case let action as DelayedAction:
+            action.called = true
+            while action.blocked { RunLoop.main.run(until: Date()) }
             state.testValue = action.value
             return state
         default:


### PR DESCRIPTION
**Make reductions thread-safe and make Store subscriptions fire on the Main Thread.**

This PR proposes a way to make store reductions thread-safe by using `objc_sync_enter` and `objc_sync_exit` synchronization primitives, using the Store itself as a lock.

```swift
open func _defaultDispatch(action: Action) {
    objc_sync_enter(self)
    let newState = reducer(action, state)
    state = newState
    objc_sync_exit(self)
}
```

**TODO:**
- [ ] Allow for the selection of a callback queue where `newState` methods will be called. The currently preferred way to do this would be to add an optional parameter when subscribing to store changes.